### PR TITLE
取消操作移除观察者。

### DIFF
--- a/Douyin/Controller/AwemeList/AVPlayer/AVPlayerView.m
+++ b/Douyin/Controller/AwemeList/AVPlayer/AVPlayerView.m
@@ -122,6 +122,7 @@
     [_queryCacheOperation cancel];
     
     _player = nil;
+    [_playerItem removeObserver:self forKeyPath:@"status"];
     _playerItem = nil;
     _playerLayer.player = nil;
     


### PR DESCRIPTION
当滑动视频的时候，有可能会出现崩溃。